### PR TITLE
fix: appData in producer creation

### DIFF
--- a/core/src/main/jni/send_transport.cpp
+++ b/core/src/main/jni/send_transport.cpp
@@ -55,7 +55,7 @@ extern "C"
                                  appData = json::parse(JavaToNativeString(env, JavaParamRef<jstring>(env, j_appData)));
                                }
 
-                               auto producer = getSendTransport(j_transport)->Produce(listener, track, &encodings, &codecOptions, &appData);
+                               auto producer = getSendTransport(j_transport)->Produce(listener, track, &encodings, &codecOptions, NULL, appData);
                                return NativeToJavaProducer(env, producer, listener).Release();
                              })
       .value_or(nullptr);


### PR DESCRIPTION
While creating the producers, appData is sent in field of `codecs` fix that by sending NULL in `codecs` and sending `appData` in the right place