### PR TITLE
fix: add missing codec param to SendTransport.produce

### DIFF
--- a/Building.md
+++ b/Building.md
@@ -6,16 +6,16 @@
 
 ## Prepare
 
-1. Editing VERSION file for specify the version of dependent libraries.
+1. Editing VERSIONS file for specify the version of dependent libraries.
 2. Download dependencies files.
 
 ```shell
-$ cd core/deps/scripts
+$ cd core/scripts
 $ ./get-deps.sh
 ```
 
 ## Building
 
 ```shell
-$ gradlew build
+$ ./gradlew build
 ```

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -4,6 +4,9 @@ build:
 complexity:
   TooManyFunctions:
     active: false
+  LongParameterList:
+    active: true
+    functionThreshold: 8
 
 style:
   WildcardImport:

--- a/core/src/main/java/io/github/crow_misia/mediasoup/SendTransport.kt
+++ b/core/src/main/java/io/github/crow_misia/mediasoup/SendTransport.kt
@@ -48,6 +48,7 @@ class SendTransport @CalledByNative private constructor(
         track: MediaStreamTrack,
         encodings: List<RtpParameters.Encoding> = emptyList(),
         codecOptions: String? = null,
+        codec: String? = null,
         appData: String? = null,
     ): Producer {
         checkTransportExists()
@@ -58,6 +59,7 @@ class SendTransport @CalledByNative private constructor(
             track = nativeTrack,
             encodings = encodings.toTypedArray(),
             codecOptions = codecOptions,
+            codec = codec,
             appData = appData,
         )
     }
@@ -98,6 +100,7 @@ class SendTransport @CalledByNative private constructor(
         track: Long,
         encodings: Array<RtpParameters.Encoding>,
         codecOptions: String?,
+        codec: String?,
         appData: String?,
     ): Producer
 

--- a/core/src/main/jni/send_transport.cpp
+++ b/core/src/main/jni/send_transport.cpp
@@ -31,7 +31,7 @@ extern jmethodID sendTransportListenerOnProduceDataMethod;
 
 extern "C"
 {
-  JNI_DEFINE_METHOD(jobject, SendTransport, nativeProduce, jlong j_transport, jobject j_listener, jlong j_track, jobjectArray j_encodings, jstring j_codecOptions, jstring j_appData)
+  JNI_DEFINE_METHOD(jobject, SendTransport, nativeProduce, jlong j_transport, jobject j_listener, jlong j_track, jobjectArray j_encodings, jstring j_codecOptions, jstring j_codec, jstring j_appData)
   {
     MSC_TRACE();
 
@@ -49,13 +49,18 @@ extern "C"
                                {
                                  codecOptions = json::parse(JavaToNativeString(env, JavaParamRef<jstring>(env, j_codecOptions)));
                                }
+                               auto codec = json::object();
+                               if (j_codec != nullptr)
+                               {
+                                 codec = json::parse(JavaToNativeString(env, JavaParamRef<jstring>(env, j_codec)));
+                               }
                                json appData = nullptr;
                                if (j_appData != nullptr)
                                {
                                  appData = json::parse(JavaToNativeString(env, JavaParamRef<jstring>(env, j_appData)));
                                }
 
-                               auto producer = getSendTransport(j_transport)->Produce(listener, track, &encodings, &codecOptions, NULL, appData);
+                               auto producer = getSendTransport(j_transport)->Produce(listener, track, &encodings, &codecOptions, &codec, appData);
                                return NativeToJavaProducer(env, producer, listener).Release();
                              })
       .value_or(nullptr);

--- a/core/src/main/jni/send_transport.h
+++ b/core/src/main/jni/send_transport.h
@@ -17,7 +17,7 @@ namespace mediasoupclient
 
 extern "C"
 {
-  JNI_DEFINE_METHOD(jobject, SendTransport, nativeProduce, jlong j_transport, jobject j_listener, jlong j_track, jobjectArray j_encodings, jstring j_codecOptions, jstring j_appData);
+  JNI_DEFINE_METHOD(jobject, SendTransport, nativeProduce, jlong j_transport, jobject j_listener, jlong j_track, jobjectArray j_encodings, jstring j_codecOptions, jstring j_codec, jstring j_appData);
   JNI_DEFINE_METHOD(jobject, SendTransport, nativeProduceData, jlong j_transport, jobject j_listener, jstring j_label, jstring j_protocol, jboolean j_ordered, jint j_maxRetransmits,
                     jint j_maxPacketLifeTime, jstring j_appData);
 }


### PR DESCRIPTION
This pull request includes updates to the build documentation and enhancements to the `SendTransport` class to support an additional codec parameter (from here [limediasoupclient](https://github.com/versatica/libmediasoupclient/blob/54645916712228ae37573f870a77ff6bbafda6e8/src/Transport.cpp#L180)). The most important changes are detailed below:

### Documentation Updates:
* [`Building.md`](diffhunk://#diff-8b19275a60c56071a9b9f4a901ad066ada06164ca002a4b5f94c80d54aba65aaL9-R20): Corrected the file name from `VERSION` to `VERSIONS` and updated the directory paths for downloading dependencies and building the project.

### Code Enhancements:
* [`core/src/main/java/io/github/crow_misia/mediasoup/SendTransport.kt`](diffhunk://#diff-971a8acfa5250e106f9629314ebb9e37a2a25e5aa1f18f106248fa9680349c78R51): Added a new `codec` parameter to the `Produce` method and updated the method calls to include this parameter. [[1]](diffhunk://#diff-971a8acfa5250e106f9629314ebb9e37a2a25e5aa1f18f106248fa9680349c78R51) [[2]](diffhunk://#diff-971a8acfa5250e106f9629314ebb9e37a2a25e5aa1f18f106248fa9680349c78R62) [[3]](diffhunk://#diff-971a8acfa5250e106f9629314ebb9e37a2a25e5aa1f18f106248fa9680349c78R103)
* [`core/src/main/jni/send_transport.cpp`](diffhunk://#diff-dd7eb2f1b44a002a0132c984020154d33118770552fb2f09d5309582c03b5989L34-R34): Updated the `nativeProduce` method to handle the new `codec` parameter and parse it from a JSON object. [[1]](diffhunk://#diff-dd7eb2f1b44a002a0132c984020154d33118770552fb2f09d5309582c03b5989L34-R34) [[2]](diffhunk://#diff-dd7eb2f1b44a002a0132c984020154d33118770552fb2f09d5309582c03b5989R52-R63)
* [`core/src/main/jni/send_transport.h`](diffhunk://#diff-165d8f2a2a0d113068d8003e2be8612681b35c29460f4cffce0f06aabe114db2L20-R20): Updated the `nativeProduce` method signature to include the new `codec` parameter.